### PR TITLE
Improve the intent attribute of arguments

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -118,5 +118,9 @@ pushd c_main
 "$fpm" run
 popd
 
+pushd preprocess_cpp
+"$fpm" build
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/src/fpm/manifest/preprocess.f90
+++ b/src/fpm/manifest/preprocess.f90
@@ -53,7 +53,7 @@ contains
       type(toml_table), intent(inout) :: table
 
       !> Error handling
-      type(error_t), allocatable, intent(inout) :: error
+      type(error_t), allocatable, intent(out) :: error
 
       call check(table, error)
       if (allocated(error)) return

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -382,9 +382,8 @@ end subroutine get_debug_compile_flags
 
 subroutine set_preprocessor_flags (id, flags, package)
     integer(compiler_enum), intent(in) :: id
+    character(len=:), allocatable, intent(inout) :: flags
     type(package_config_t), intent(in) :: package
-    type(error_t), allocatable :: error
-    character(len=:), allocatable :: flags
     character(len=:), allocatable :: flag_cpp_preprocessor
     
     integer :: i
@@ -424,15 +423,14 @@ end subroutine set_preprocessor_flags
 !> under preprocess section for a specific preprocessor
 subroutine get_macros_from_manifest(id, flags, package, index_of_preprocessor)
     integer(compiler_enum), intent(in) :: id
+    character(len=:), allocatable, intent(inout) :: flags
     type(package_config_t), intent(in) :: package
-    type(error_t), allocatable :: error
-    character(len=:), allocatable :: flags
+    integer, intent(in) :: index_of_preprocessor
     character(len=:), allocatable :: macro_definition_symbol
     character(:), allocatable :: valued_macros(:)
     character(len=:), allocatable :: version
 
     integer :: i
-    integer :: index_of_preprocessor
 
     !> Check if there is a preprocess table
     if (.not.allocated(package%preprocess)) then


### PR DESCRIPTION
Hi, @arteevraina .

I saw you posted [a post](https://fortran-lang.discourse.group/t/operating-system-error-cannot-allocate-memory/4034) on Fortran Discourse, and this commit may be related to the content of that post.
- Mainly improved the `intent` attribute of arguments.
- Introduce the `preprocess_cpp` example package into CI (run_tests.sh).
- Remove unused `error` parameters.